### PR TITLE
Fix cmake pkg-config install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,5 +63,5 @@ install(DIRECTORY ${HTTPMOCKSERVER_INCLUDE_DIRS}/httpmockserver
 # set pkg-config file
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 configure_file("libhttpmockserver.pc.in" "libhttpmockserver.pc" @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/libhttpmockserver.pc DESTINATION lib/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libhttpmockserver.pc DESTINATION lib/pkgconfig)
 


### PR DESCRIPTION
While using httpmockserver as dependency, recursive installation fails
since the CMAKE_BINARY_DIR is pointing to the root of the invoker
project, instead of the dependency directory.

This patch corrects the path for isntalling httpmockserver files.

Fixes: #9

Signed-off-by: Ladislav Macoun <ladislavmacoun@gmail.com>